### PR TITLE
Add node management scaffolding for multi-server support

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -35,6 +35,7 @@ func initModels() error {
 		&model.InboundClientIps{},
 		&xray.ClientTraffic{},
 		&model.HistoryOfSeeders{},
+		&model.Node{},
 	}
 	for _, model := range models {
 		if err := db.AutoMigrate(model); err != nil {

--- a/database/model/node.go
+++ b/database/model/node.go
@@ -1,0 +1,9 @@
+package model
+
+// Node represents a remote server that can be managed by the panel.
+type Node struct {
+	Id     int    `json:"id" gorm:"primaryKey;autoIncrement"`
+	Name   string `json:"name"`
+	ApiURL string `json:"apiUrl"`
+	ApiKey string `json:"apiKey"`
+}

--- a/web/controller/node.go
+++ b/web/controller/node.go
@@ -1,0 +1,48 @@
+package controller
+
+import (
+	"net/http"
+
+	"x-ui/web/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+// NodeController handles HTTP requests for managed nodes.
+type NodeController struct {
+	BaseController
+
+	nodeService service.NodeService
+}
+
+func NewNodeController(g *gin.RouterGroup) *NodeController {
+	a := &NodeController{}
+	a.initRouter(g)
+	return a
+}
+
+func (a *NodeController) initRouter(g *gin.RouterGroup) {
+	g = g.Group("/nodes")
+	g.Use(a.checkLogin)
+	g.GET("", a.list)
+	g.POST("", a.create)
+}
+
+func (a *NodeController) list(c *gin.Context) {
+	nodes, err := a.nodeService.List()
+	jsonObj(c, nodes, err)
+}
+
+func (a *NodeController) create(c *gin.Context) {
+	var req struct {
+		Name   string `json:"name"`
+		ApiURL string `json:"apiUrl"`
+		ApiKey string `json:"apiKey"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "msg": err.Error()})
+		return
+	}
+	err := a.nodeService.Create(req.Name, req.ApiURL, req.ApiKey)
+	jsonMsg(c, "", err)
+}

--- a/web/service/node.go
+++ b/web/service/node.go
@@ -1,0 +1,22 @@
+package service
+
+import (
+	"x-ui/database"
+	"x-ui/database/model"
+)
+
+// NodeService provides CRUD operations for managed nodes.
+type NodeService struct{}
+
+func (s *NodeService) List() ([]model.Node, error) {
+	db := database.GetDB()
+	var nodes []model.Node
+	err := db.Find(&nodes).Error
+	return nodes, err
+}
+
+func (s *NodeService) Create(name, apiURL, apiKey string) error {
+	db := database.GetDB()
+	node := &model.Node{Name: name, ApiURL: apiURL, ApiKey: apiKey}
+	return db.Create(node).Error
+}

--- a/web/web.go
+++ b/web/web.go
@@ -86,6 +86,7 @@ type Server struct {
 	server *controller.ServerController
 	panel  *controller.XUIController
 	api    *controller.APIController
+	node   *controller.NodeController
 
 	xrayService    service.XrayService
 	settingService service.SettingService
@@ -232,6 +233,7 @@ func (s *Server) initRouter() (*gin.Engine, error) {
 	s.server = controller.NewServerController(g)
 	s.panel = controller.NewXUIController(g)
 	s.api = controller.NewAPIController(g)
+	s.node = controller.NewNodeController(g)
 
 	return engine, nil
 }


### PR DESCRIPTION
## Summary
- add `Node` model for storing remote server details
- create Node service and controller with basic list/create endpoints
- register node controller in web server initialization

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b137e606ec8327a390af0f5174e58e