### PR TITLE
feat: add multi-server setting toggle

### DIFF
--- a/web/controller/setting.go
+++ b/web/controller/setting.go
@@ -67,7 +67,10 @@ func (a *SettingController) updateSetting(c *gin.Context) {
 		jsonMsg(c, I18nWeb(c, "pages.settings.toasts.modifySettings"), err)
 		return
 	}
-	err = a.settingService.UpdateAllSetting(allSetting)
+	err = a.settingService.SetMultiServerEnabled(allSetting.MultiServer)
+	if err == nil {
+		err = a.settingService.UpdateAllSetting(allSetting)
+	}
 	jsonMsg(c, I18nWeb(c, "pages.settings.toasts.modifySettings"), err)
 }
 

--- a/web/entity/entity.go
+++ b/web/entity/entity.go
@@ -23,6 +23,7 @@ type AllSetting struct {
 	WebCertFile                 string `json:"webCertFile" form:"webCertFile"`
 	WebKeyFile                  string `json:"webKeyFile" form:"webKeyFile"`
 	WebBasePath                 string `json:"webBasePath" form:"webBasePath"`
+	MultiServer                 bool   `json:"multiServer" form:"multiServer"`
 	SessionMaxAge               int    `json:"sessionMaxAge" form:"sessionMaxAge"`
 	PageSize                    int    `json:"pageSize" form:"pageSize"`
 	ExpireDiff                  int    `json:"expireDiff" form:"expireDiff"`

--- a/web/html/settings/panel/general.html
+++ b/web/html/settings/panel/general.html
@@ -50,6 +50,12 @@
             </template>
         </a-setting-list-item>
         <a-setting-list-item paddings="small">
+            <template #title>{{ i18n "pages.settings.multiServer"}}</template>
+            <template #control>
+                <a-switch v-model="allSetting.multiServer"></a-switch>
+            </template>
+        </a-setting-list-item>
+        <a-setting-list-item paddings="small">
             <template #title>{{ i18n "pages.settings.sessionMaxAge" }}</template>
             <template #description>{{ i18n "pages.settings.sessionMaxAgeDesc" }}</template>
             <template #control>

--- a/web/service/setting.go
+++ b/web/service/setting.go
@@ -32,6 +32,7 @@ var defaultValueMap = map[string]string{
 	"webKeyFile":                  "",
 	"secret":                      random.Seq(32),
 	"webBasePath":                 "/",
+	"multiServer":                 "false",
 	"sessionMaxAge":               "360",
 	"pageSize":                    "50",
 	"expireDiff":                  "0",
@@ -527,6 +528,14 @@ func (s *SettingService) SetExternalTrafficInformURI(InformURI string) error {
 	return s.setString("externalTrafficInformURI", InformURI)
 }
 
+func (s *SettingService) GetMultiServerEnabled() (bool, error) {
+	return s.getBool("multiServer")
+}
+
+func (s *SettingService) SetMultiServerEnabled(value bool) error {
+	return s.setBool("multiServer", value)
+}
+
 func (s *SettingService) GetIpLimitEnable() (bool, error) {
 	accessLogPath, err := xray.GetAccessLogPath()
 	if err != nil {
@@ -546,6 +555,9 @@ func (s *SettingService) UpdateAllSetting(allSetting *entity.AllSetting) error {
 	errs := make([]error, 0)
 	for _, field := range fields {
 		key := field.Tag.Get("json")
+		if key == "multiServer" {
+			continue
+		}
 		fieldV := v.FieldByName(field.Name)
 		value := fmt.Sprint(fieldV.Interface())
 		err := s.saveSetting(key, value)

--- a/web/web.go
+++ b/web/web.go
@@ -233,7 +233,13 @@ func (s *Server) initRouter() (*gin.Engine, error) {
 	s.server = controller.NewServerController(g)
 	s.panel = controller.NewXUIController(g)
 	s.api = controller.NewAPIController(g)
-	s.node = controller.NewNodeController(g)
+	multiServerEnabled, err := s.settingService.GetMultiServerEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if multiServerEnabled {
+		s.node = controller.NewNodeController(g)
+	}
 
 	return engine, nil
 }


### PR DESCRIPTION
## Summary
- добавить настройку `multiServer` с хранением и методами получения
- добавить переключатель множественных серверов в панели настроек
- инициализировать контроллер узлов только при включённой опции

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b13af18314832785baf3979dbaa0bf